### PR TITLE
Replace stub/virtualize usage with mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ This section will walk you through each of the steps that were programmatically 
 * Start the stub Server
 * For Unix and PowerShell:<br/><br/>
   ```shell
-  docker run --rm -v "$(pwd)/specmatic.yaml:/usr/src/app/specmatic.yaml" -v "$(pwd)/examples:/usr/src/app/examples/domain_service" -p 9000:9000 specmatic/specmatic stub --examples=examples
+  docker run --rm -v "$(pwd)/specmatic.yaml:/usr/src/app/specmatic.yaml" -v "$(pwd)/examples:/usr/src/app/examples/domain_service" -p 9000:9000 specmatic/specmatic mock --examples=examples
   ```
 * For Windows CMD Prompt:<br/><br/>
   ```shell
-  docker run --rm -v "%cd%/specmatic.yaml:/usr/src/app/specmatic.yaml" -v "%cd%/examples:/usr/src/app/examples/domain_service" -p 9000:9000 specmatic/specmatic stub --examples=examples
+  docker run --rm -v "%cd%/specmatic.yaml:/usr/src/app/specmatic.yaml" -v "%cd%/examples:/usr/src/app/examples/domain_service" -p 9000:9000 specmatic/specmatic mock --examples=examples
   ```
 
 

--- a/specmatic-order-bff-csharp.test/contract/ContractTests.cs
+++ b/specmatic-order-bff-csharp.test/contract/ContractTests.cs
@@ -90,7 +90,7 @@ public class ContractTests : IAsyncLifetime
     private async Task StartDomainServiceStub()
     {
         _stubContainer = new ContainerBuilder()
-            .WithImage("specmatic/specmatic").WithCommand("stub")
+            .WithImage("specmatic/specmatic").WithCommand("mock")
             .WithCommand("--examples=examples")
             .WithPortBinding(9000)
             .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())


### PR DESCRIPTION
## Summary
- replace remaining Specmatic command usage of \ and \ with \
- update test-container startup checks to match mock server logs where applicable

## Validation
- searched codebase for remaining command-form usage of \Using bleeding edge Specmatic build

Error: No jar file found matching pattern: /Users/naresh/projects/specmatic-all/specmatic/application/build/libs/specmatic*-all-un*.jar and \